### PR TITLE
Use `SerializeReference` for doc comments & decorators

### DIFF
--- a/Editor/AirshipComponentEditor.cs
+++ b/Editor/AirshipComponentEditor.cs
@@ -384,14 +384,14 @@ public class ScriptBindingEditor : UnityEditor.Editor {
         var decoratorDictionary = GetDecorators(bindingProp);
 
         var documentation = bindingProp.Documentation;
-        var tooltip = GetTooltip(documentation.Tooltip ?? "", decoratorDictionary);
+        var tooltip = GetTooltip(documentation?.Tooltip ?? "", decoratorDictionary);
         
         
         var guiContent = new GUIContent(propNameDisplay, tooltip);
         
         var arrayElementType = LuauMetadataPropertySerializer.GetAirshipComponentPropertyTypeFromString(
             items.FindPropertyRelative("type").stringValue, 
-            HasDecorator(decorators, "int")
+            false
         );
         
         // Loop over styling decorators to display them in same order they were passed in

--- a/Runtime/Code/Luau/LuauMetadata.cs
+++ b/Runtime/Code/Luau/LuauMetadata.cs
@@ -209,7 +209,9 @@ namespace Luau {
     [Serializable]
     public class LuauMetadataDocComment {
         public string comment;
+        [SerializeReference]
         public List<LuauMetadataDocComment> comments = new();
+        [SerializeReference]
         public List<LuauMetadataDocTag> tags = new();
 
         public string Text {
@@ -233,7 +235,9 @@ namespace Luau {
     
     [Serializable]
     public class LuauMetadataDoc {
+        [SerializeReference]
         public List<LuauMetadataDocComment> comments = new();
+        [SerializeReference]
         public List<LuauMetadataDocTag> tags = new();
         
         /// <summary>
@@ -278,13 +282,13 @@ namespace Luau {
         public string fileRef;
 
 #if UNITY_EDITOR
-        [JsonProperty][SerializeField]
+        [JsonProperty][SerializeReference]
 #endif
         private LuauMetadataDoc docs;
         public LuauMetadataDoc Documentation => docs;
         
         #if UNITY_EDITOR
-        [JsonProperty][SerializeField]
+        [JsonProperty][SerializeReference]
         #endif
         private List<LuauMetadataDecoratorElement> decorators = new();
         public bool nullable;


### PR DESCRIPTION
This will store the given properties _by reference_, meaning that they should only apply to the serialized objects themselves, and fixes the issue with recursive and duplicate data caused by `[SerializeField]` storing by value. (see [here](https://www.youtube.com/watch?v=6mtV7anusYo) for details)

This does have the side effect of essentially setting these properties to `null` in prefabs - but given the docs and decorators are grabbed from the scripts - this is fine and actually helps us reduce redundant data.