### PR TITLE
Character Parenting

### DIFF
--- a/Runtime/Code/Player/Character/MovementSystems/Character/CharacterMovement.cs
+++ b/Runtime/Code/Player/Character/MovementSystems/Character/CharacterMovement.cs
@@ -1451,28 +1451,12 @@ namespace Code.Player.Character.MovementSystems.Character {
 
             if (this.parentFollowingEnabled && this.trackedParent != null)
             {
-                Vector3 oldPlayerPosition = this.rb.position;
-                Quaternion oldPlayerRotation = this.rb.rotation;
-    
                 Vector3 oldParentPosition = currentMoveSnapshot.parentPosition ?? this.trackedParent.transform.position;
                 Quaternion oldParentRotation = Quaternion.Euler(currentMoveSnapshot.parentRotation ?? this.trackedParent.transform.rotation.eulerAngles);
 
-                Vector3 newParentPosition = this.trackedParent.transform.position;
-                Quaternion newParentRotation = this.trackedParent.transform.rotation;
-
-
-                Vector3 localPosition = Quaternion.Inverse(oldParentRotation) * (oldPlayerPosition - oldParentPosition);
-                Quaternion localRotation = Quaternion.Inverse(oldParentRotation) * oldPlayerRotation;
-
-                // 3. Apply local position/rotation to new green transform
-                Vector3 newPlayerPosition = newParentRotation * localPosition + newParentPosition;
-                Vector3 newPlayerRotation = (newParentRotation * localRotation).eulerAngles;
-
-                this.rb.position = newPlayerPosition;
-                this.rb.rotation = Quaternion.Euler(newPlayerRotation);
-
+                this.rb.position = this.trackedParent.transform.rotation * Quaternion.Inverse(oldParentRotation) * (this.rb.position - oldParentPosition) + this.trackedParent.transform.position;
+                this.rb.rotation = Quaternion.Euler((this.trackedParent.transform.rotation * Quaternion.Inverse(oldParentRotation) * this.rb.rotation).eulerAngles);
                 
-
                 currentMoveSnapshot.parentPosition = this.trackedParent.transform.position;
                 currentMoveSnapshot.parentRotation = this.trackedParent.transform.rotation.eulerAngles;
             }


### PR DESCRIPTION
Added the ability to connect the character to another game object that inherits its position and rotation.
For example, a user walking on stable ground would be parented to nothing; however, a user standing on a boat would be parented to that boat so they don't fall off when turning/moving.

Compared to the prior solution of AddImpulse, this performs much better, allowing the player to still control their character and calculates the object turning so the player moves with the turn.

I did have some issues, such as the C# functions would not appear in my project, so I just manually edited the type definitions.

Example use:
```ts
import { Airship } from "@Easy/Core/Shared/Airship";
import { Game } from "@Easy/Core/Shared/Game";

export default class ParentTouchedCharComponent extends AirshipBehaviour {
    public parent: GameObject;
    protected OnCollisionEnter(collision: Collision): void {
        if (!Game.IsServer()) return;
        const char = Airship.Characters.FindByCollider(collision.collider);
        if (char === undefined) return;
        if (this.parent === undefined) {
            char.movement.RemoveTrackedParent();
        } else {
            char.movement.SetTrackedParent(this.parent);
        }
    }
}

```
Some videos of comparison are posted here https://discord.com/channels/1200528095896158218/1402297830286299177

**EDIT: I found a way to do it by adding a component to the character prefab so... yeah... it was fun i guess xD**