### PR TITLE
Always detach OnLuauReset on destroy & when reset

### DIFF
--- a/Runtime/Code/Luau/AirshipComponent.cs
+++ b/Runtime/Code/Luau/AirshipComponent.cs
@@ -325,6 +325,7 @@ public class AirshipComponent : MonoBehaviour, ITriggerReceiver {
 	
 	private void OnDestroy() {
 		ComponentIdToScriptName.Remove(_airshipComponentId);
+		LuauCore.onResetInstance -= OnLuauReset;
 		
 		if (thread == IntPtr.Zero || !LuauCore.IsReady) return;
 		
@@ -336,7 +337,6 @@ public class AirshipComponent : MonoBehaviour, ITriggerReceiver {
 			LuauPlugin.LuauDestroyThread(thread);
 		}
 		thread = IntPtr.Zero;
-		LuauCore.onResetInstance -= OnLuauReset;
 	}
 
 	#region Collision Events
@@ -460,6 +460,7 @@ public class AirshipComponent : MonoBehaviour, ITriggerReceiver {
 	private void OnLuauReset(LuauContext ctx) {
 		if (ctx == context) {
 			thread = IntPtr.Zero;
+			LuauCore.onResetInstance -= OnLuauReset;
 		}
 	}
 


### PR DESCRIPTION
I believe there is a (common) case where an AirshipComponent can be destroyed after LuauCore.onResetInstance has been called. In this case we weren't clearing the subscribed delegate, causing a leak. This change guarantees that the delegate is unsubscribed in OnDestroy (as a fallback) and also unsubscribes it once OnResetContext has fired successfully (and thread is cleared).