### PR TITLE
Fix ambiguity errors when trying to use static method defaults with multiple overloads

### DIFF
--- a/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
+++ b/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -23,8 +21,6 @@ namespace Luau {
             { "AnimationCurve", typeof(AnimationCurve) },
         };
 
-        private static readonly Type QuaternionType = typeof(Quaternion);
-        
         public static string SerializeAirshipProperty(object obj, AirshipComponentPropertyType objectType) {
             switch (objectType) {
                 case AirshipComponentPropertyType.AirshipFloat: {

--- a/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
+++ b/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -20,6 +22,8 @@ namespace Luau {
             { "LayerMask", typeof(LayerMask) },
             { "AnimationCurve", typeof(AnimationCurve) },
         };
+
+        private static readonly Type QuaternionType = typeof(Quaternion);
         
         public static string SerializeAirshipProperty(object obj, AirshipComponentPropertyType objectType) {
             switch (objectType) {
@@ -68,15 +72,19 @@ namespace Luau {
                             obj = Activator.CreateInstance(objType, args);
                         } else if (objDefaultVal.target == "method") {
                             var args = objDefaultVal.arguments.ToArray();
-                            for (var i = 0; i < args.Length; i++)
-                            {
-                                if (args[i] is double)
-                                {
+                            for (var i = 0; i < args.Length; i++) {
+                                if (args[i] is double) {
                                     args[i] = Convert.ToSingle(args[i]);
                                 }
                             }
 
-                            var expectedMethod = objType.GetMethod(objDefaultVal.method);
+                            // Pass the argument types to GetMethod to clear any ambiguity
+                            var argTypes = new Type[args.Length];
+                            for (var i = 0; i < argTypes.Length; i++) {
+                                argTypes[i] = args[i].GetType();
+                            }
+    
+                            var expectedMethod = objType.GetMethod(objDefaultVal.method, argTypes);
                             obj = expectedMethod?.Invoke(null, args);
                         }
 

--- a/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
+++ b/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
@@ -68,15 +68,14 @@ namespace Luau {
                             obj = Activator.CreateInstance(objType, args);
                         } else if (objDefaultVal.target == "method") {
                             var args = objDefaultVal.arguments.ToArray();
+                            
+                            var argTypes = new Type[args.Length];
                             for (var i = 0; i < args.Length; i++) {
                                 if (args[i] is double) {
                                     args[i] = Convert.ToSingle(args[i]);
                                 }
-                            }
-
-                            // Pass the argument types to GetMethod to clear any ambiguity
-                            var argTypes = new Type[args.Length];
-                            for (var i = 0; i < argTypes.Length; i++) {
+                                
+                                // Pass the argument types to GetMethod to clear any ambiguity
                                 argTypes[i] = args[i].GetType();
                             }
     


### PR DESCRIPTION
E.g. `Quaternion.Euler`, contains `Quaternion.Euler(x, y, z)` and `Quaternion.Euler(vector)`.

Previous exception-causing behaviour would be from `GetMethod` throwing an `AmbiguousMatchException` due to having two overloads with the above.

This PR introduces passing the argument types explicitly to `GetMethod`, removing the ambiguity.