### PR TITLE
Only try overwriting static reference and log if failed

### DIFF
--- a/Runtime/Code/Components/DynamicVariables/GameObjectReferences.cs
+++ b/Runtime/Code/Components/DynamicVariables/GameObjectReferences.cs
@@ -50,7 +50,7 @@ public class GameObjectReferences : MonoBehaviour {
     private void Awake() {
         if (isStaticInstance) {
             if (!AllReferences.TryAdd(staticBundleId, this)) {
-                Debug.LogWarning($"Duplicate instance of static GameObjectReferences for key {staticBundleId}", this.gameObject);
+                Debug.LogError($"Duplicate instance of static GameObjectReferences for key {staticBundleId}", this.gameObject);
             }
         }
 


### PR DESCRIPTION
This would give a hard to understand error before. Changed it to log error (so non static access to the component still works) and made the error a bit more readable (before it just complained about duplicate dictionary keys).