### PR TITLE
Add editor support for rect pod type

### DIFF
--- a/Editor/AirshipComponentEditor.cs
+++ b/Editor/AirshipComponentEditor.cs
@@ -1083,10 +1083,10 @@ public class ScriptBindingEditor : UnityEditor.Editor {
     
     private void DrawCustomRectProperty(GUIContent guiContent, SerializedProperty type, SerializedProperty modifiers, SerializedProperty value, SerializedProperty modified)
     {
-        var currentValue = JsonUtility.FromJson<Rect>(value.stringValue);
+        var currentValue = LuauMetadataPropertySerializer.DeserializeRect(value.stringValue);
         var newValue = EditorGUILayout.RectField(guiContent, currentValue);
         if (newValue != currentValue) {
-            value.stringValue = JsonUtility.ToJson(newValue);
+            value.stringValue = LuauMetadataPropertySerializer.SerializeRect(newValue);
             modified.boolValue = true;
         }
     }

--- a/Runtime/Code/Luau/LuauMetadata.cs
+++ b/Runtime/Code/Luau/LuauMetadata.cs
@@ -275,7 +275,7 @@ namespace Luau {
             { "Vector2", PODTYPE.POD_VECTOR2 },
             { "Quaternion", PODTYPE.POD_QUATERNION },
             { "Matrix4x4", PODTYPE.POD_MATRIX },
-            // { "Rect", PODTYPE.POD_RECT }, // POD_RECT doesn't exist
+            { "Rect", PODTYPE.POD_RECT },
             // { "LayerMask", PODTYPE.POD_LAYERMASK }, // POD_LAYERMASK doesn't exist
         };
 
@@ -514,6 +514,12 @@ namespace Luau {
                 }
                 case AirshipComponentPropertyType.AirshipPod: {
                     var objType = TypeReflection.GetTypeFromString(typeStr);
+                    // JsonUtility doesn't support Rect
+                    if (objType == typeof(Rect)) {
+                        obj = LuauMetadataPropertySerializer.DeserializeRect(serializedObjectValue);
+                        break;
+                    }
+                    
                     obj = JsonUtility.FromJson(serializedObjectValue, objType);
                     if (obj == null) {
                         obj = Activator.CreateInstance(objType);

--- a/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
+++ b/Runtime/Code/Luau/LuauMetadataPropertySerializer.cs
@@ -21,8 +21,8 @@ namespace Luau {
             { "AnimationCurve", typeof(AnimationCurve) },
         };
 
-        public static string SerializeAirshipProperty(object obj, AirshipComponentPropertyType objectType) {
-            switch (objectType) {
+        public static string SerializeAirshipProperty(object obj, AirshipComponentPropertyType airshipPropertyType) {
+            switch (airshipPropertyType) {
                 case AirshipComponentPropertyType.AirshipFloat: {
                     return Convert.ToSingle(obj).ToString(CultureInfo.InvariantCulture);
                 }
@@ -83,9 +83,12 @@ namespace Luau {
                             obj = expectedMethod?.Invoke(null, args);
                         }
 
-                        // Can't use JSONUtility on AnimationCurve
-                        if (objectType == AirshipComponentPropertyType.AirshipAnimationCurve) {
+                        // Can't use JSONUtility on AnimationCurve or Rect
+                        if (airshipPropertyType == AirshipComponentPropertyType.AirshipAnimationCurve) {
                             return SerializeAnimationCurve(obj as AnimationCurve);
+                        }
+                        if (objType == typeof(Rect)) {
+                            return SerializeRect((Rect) obj);
                         }
 
                         return JsonUtility.ToJson(obj);
@@ -100,6 +103,26 @@ namespace Luau {
             }
             Debug.Log($"Failed to serialize object: {obj.ToString()}");
             return "";
+        }
+        
+        /// <summary>
+        /// Serializes a rect as "x,y,width,height"
+        /// </summary>
+        public static string SerializeRect(Rect rect) {
+            return $"{rect.x.ToString(CultureInfo.InvariantCulture)},{rect.y.ToString(CultureInfo.InvariantCulture)},{rect.width.ToString(CultureInfo.InvariantCulture)},{rect.height.ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        public static Rect DeserializeRect(string serializedRect) {
+            var elements = serializedRect.Split(",");
+            if (elements.Length != 4) {
+                return default;
+            }
+            
+            var x = float.Parse(elements[0], CultureInfo.InvariantCulture);
+            var y = float.Parse(elements[1], CultureInfo.InvariantCulture);
+            var width = float.Parse(elements[2], CultureInfo.InvariantCulture);
+            var height = float.Parse(elements[3], CultureInfo.InvariantCulture);
+            return new Rect(x, y, width, height);
         }
         
         public static string SerializeAnimationCurve(AnimationCurve curve) {


### PR DESCRIPTION
Adds rect to builtin list and adds custom serialization for it (JsonUtility wasn't able to serialize Rect correctly).

```ts
export default class RectTest extends AirshipBehaviour {
	public rect = new Rect(1, 2, 3, 4);
```
<img width="401" height="117" alt="Screenshot 2025-09-08 at 11 40 45 AM" src="https://github.com/user-attachments/assets/1fc1b3a7-23be-4dc1-bf50-2099a9f0b561" />