### PR TITLE
Additional security + easy way to override

### DIFF
--- a/Runtime/Code/Luau/LuauAssembly/LuauAPI.cs
+++ b/Runtime/Code/Luau/LuauAssembly/LuauAPI.cs
@@ -1,9 +1,20 @@
 using System;
+using System.Collections.Generic;
 
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field)]
 public class LuauAPIAttribute : Attribute {
     public readonly LuauContext AllowedContextsMask;
-
+    /// <summary>
+    /// List of method/member names that will ignore the AllowedContextsMask. By default
+    /// these will be accessible to all contexts but that can be configured by changing the
+    /// ContextOverrideMask parameter.
+    /// </summary>
+    public string[] ContextOverrideList;
+    /// <summary>
+    /// If ContextOverrideList is provided then all methods/members listed will use this context mask.
+    /// </summary>
+    public int ContextOverrideMask = ~0;
+    
     /// <summary>
     /// Allow the given Luau contexts to access this type. For multiple types,
     /// use bit-masking.

--- a/Runtime/Code/Luau/LuauCoreCallbacks.cs
+++ b/Runtime/Code/Luau/LuauCoreCallbacks.cs
@@ -780,36 +780,50 @@ public partial class LuauCore : MonoBehaviour {
                 return LuauError(thread, "ERROR - type of " + staticClassName + " class not found");
             }
 
-            Type objectType = staticClassApi.GetAPIType();
+            var classType = staticClassApi.GetAPIType();
+            
             if (printReferenceAssemblies) {
-                referencedAssemblies.Add(objectType.Assembly.FullName);
+                referencedAssemblies.Add(classType.Assembly.FullName);
             }
 
             // Get PropertyInfo from cache if possible -- otherwise put it in cache
             PropertyGetReflectionCache? cacheData;
-            if (!(cacheData = LuauCore.GetPropertyCacheValue(objectType, propName)).HasValue) {
-                var propertyInfo = objectType.GetProperty(propName,
+            if (!(cacheData = LuauCore.GetPropertyCacheValue(classType, propName)).HasValue) {
+                var propertyInfo = classType.GetProperty(propName,
                     BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
-                cacheData = LuauCore.SetPropertyCacheValue(objectType, propName, propertyInfo);
+                cacheData = LuauCore.SetPropertyCacheValue(classType, propName, propertyInfo);
             }
 
+            // Try access as PropertyInfo
             if (cacheData.Value.Exists) {
-                // Type t = propertyInfo.PropertyType;
+                if (!ReflectionList.IsMemberAllowed(classType, cacheData.Value.propertyInfo, context)) {
+                    return LuauError(thread, $"[Airship] Access denied when trying to read {staticClassName}.{propName}.");
+                }
+                
                 System.Object value = cacheData.Value.propertyInfo.GetValue(null);
                 WritePropertyToThread(thread, value, cacheData.Value.t);
                 return 1;
             }
 
-            // Get C# event:
-            var eventInfo = objectType.GetRuntimeEvent(propName);
+            // Try access as C# event
+            var eventInfo = classType.GetRuntimeEvent(propName);
             if (eventInfo != null) {
+                if (!ReflectionList.IsMemberAllowed(classType, eventInfo, context)) {
+                    return LuauError(thread, $"[Airship] Access denied when trying to read {staticClassName}.{propName}.");
+                }
+                
                 return LuauSignalWrapper.HandleCsEvent(context, thread, staticClassApi, instanceId, propNameHash,
                     eventInfo, true);
             }
 
-            FieldInfo fieldInfo = objectType.GetField(propName,
+            // Try access as FieldInfo
+            FieldInfo fieldInfo = classType.GetField(propName,
                 BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
             if (fieldInfo != null) {
+                if (!ReflectionList.IsMemberAllowed(classType, fieldInfo, context)) {
+                    return LuauError(thread, $"[Airship] Access denied when trying to read {staticClassName}.{propName}.");
+                }
+                
                 Type t = fieldInfo.FieldType;
                 System.Object value = fieldInfo.GetValue(null);
                 WritePropertyToThread(thread, value, t);

--- a/Runtime/Code/Luau/LuauCoreCallbacks.cs
+++ b/Runtime/Code/Luau/LuauCoreCallbacks.cs
@@ -877,7 +877,11 @@ public partial class LuauCore : MonoBehaviour {
             }
 
             if (cacheData.Value.Exists) {
-                Type t = cacheData.Value.t;
+                var propertyType = cacheData.Value.t;
+                if (!ReflectionList.IsMemberAllowed(sourceType, cacheData.Value.propertyInfo, context)) {
+                    return LuauError(thread, $"[Airship] Access denied when trying to read {sourceType.Name}.{propName}.");
+                }
+                
                 try {
                     // Try a fast write on value type (Vector3, int, etc. Not objects)
                     if (FastGetAndWriteValueProperty(thread, objectReference, cacheData.Value)) {
@@ -921,7 +925,7 @@ public partial class LuauCore : MonoBehaviour {
                                 instanceId, propNameHash, sliderEvent);
                         }
 
-                        WritePropertyToThread(thread, value, t);
+                        WritePropertyToThread(thread, value, propertyType);
                         return 1;
                     }
                     else {
@@ -993,15 +997,23 @@ public partial class LuauCore : MonoBehaviour {
             // Get C# event:
             var eventInfo = sourceType.GetRuntimeEvent(propName);
             if (eventInfo != null) {
+                if (!ReflectionList.IsMemberAllowed(sourceType, eventInfo, context)) {
+                    return LuauError(thread, $"[Airship] Access denied when trying to read {sourceType.Name}.{propName}.");
+                }
+                
                 return LuauSignalWrapper.HandleCsEvent(context, thread, objectReference, instanceId, propNameHash,
                     eventInfo, false);
             }
             
             // Get field:
-            FieldInfo field = instance.GetFieldInfoForType(sourceType, propName, propNameHash);
-            if (field != null) {
-                Type t = field.FieldType;
-                System.Object value = field.GetValue(objectReference);
+            var fieldInfo = instance.GetFieldInfoForType(sourceType, propName, propNameHash);
+            if (fieldInfo != null) {
+                if (!ReflectionList.IsMemberAllowed(sourceType, fieldInfo, context)) {
+                    return LuauError(thread, $"[Airship] Access denied when trying to read {sourceType.Name}.{propName}.");
+                }
+                
+                Type t = fieldInfo.FieldType;
+                System.Object value = fieldInfo.GetValue(objectReference);
                 WritePropertyToThread(thread, value, t);
                 return 1;
             }

--- a/Runtime/Code/Luau/LuauCoreReflection.cs
+++ b/Runtime/Code/Luau/LuauCoreReflection.cs
@@ -1231,7 +1231,7 @@ public partial class LuauCore : MonoBehaviour
                 bool match = MatchParameters(numParameters, parameters, podTypes, podObjects, podIsTable, contextAttached);
                 if (match) {
                     if (!type.IsArray) {
-                        if (!ReflectionList.IsMethodAllowed(type, info, context)) {
+                        if (!ReflectionList.IsMemberAllowed(type, info, context)) {
                             insufficientContext = true;
                             return;
                         }
@@ -1276,7 +1276,7 @@ public partial class LuauCore : MonoBehaviour
             bool match = MatchParameters(numParameters, parameters, podTypes, podObjects, podIsTable, false);
 
             if (match) {
-                if (!ReflectionList.IsMethodAllowed(type, info, context)) {
+                if (!ReflectionList.IsMemberAllowed(type, info, context)) {
                     insufficientContext = true;
                     return;
                 }

--- a/Runtime/Code/Luau/ReflectionList.cs
+++ b/Runtime/Code/Luau/ReflectionList.cs
@@ -247,7 +247,7 @@ namespace Luau {
         };
 
         public static Dictionary<Type, LuauContext> allowedTypesInternal;
-        private static Dictionary<MethodInfo, LuauContext> _allowedMethodInfos;
+        private static Dictionary<MemberInfo, int> _memberInfoContextMasks;
         
         private static Dictionary<string, Type> _stringToTypeCache;
         private static Dictionary<Assembly, List<string>> _assemblyNamespaces;
@@ -264,8 +264,12 @@ namespace Luau {
             allowedTypesInternal[t] = contextMask;
         }
 
-        public static void AddToMethodList(MethodInfo info, LuauContext contextMask) {
-            _allowedMethodInfos.TryAdd(info, contextMask);
+        /// <summary>
+        /// Tries to register a context mask for a MethodInfo. If the MethodInfo already has a context mask
+        /// returns false and does nothing.
+        /// </summary>
+        public static bool RegisterMemberInfoContextMask(MemberInfo info, int contextMask) {
+            return _memberInfoContextMasks.TryAdd(info, contextMask);
         }
 
         /// <summary>
@@ -299,7 +303,11 @@ namespace Luau {
             return allowed;
         }
 
-        public static bool IsMethodAllowed(Type classType, MethodInfo methodInfo, LuauContext context) {
+        /// <summary>
+        /// If provided MemberInfo has an explicit context mask we compare against that. Otherwise this falls back
+        /// to checking if IsAllowed on the classType.
+        /// </summary>
+        public static bool IsMemberAllowed(Type classType, MemberInfo memberInfo, LuauContext context) {
             if (!IsReflectionListEnabled) return true;
 
             // Protected context has access to all
@@ -307,13 +315,13 @@ namespace Luau {
                 return true;
             }
 
-            if (_allowedMethodInfos.TryGetValue(methodInfo, out var methodMask)) {
-                return (methodMask & context) != 0;
+            if (_memberInfoContextMasks.TryGetValue(memberInfo, out var methodMask)) {
+                return (methodMask & (int) context) != 0;
             }
 
             return IsAllowed(classType, context);
         }
-
+        
         public static bool IsAllowedFromString(string typeStr, LuauContext context) {
             if (_stringToTypeCache.TryGetValue(typeStr, out var t)) {
                 return IsAllowed(t, context);
@@ -383,7 +391,7 @@ namespace Luau {
         private static void Reset() {
             allowedTypesInternal = new Dictionary<Type, LuauContext>(AllowedTypes);
             _stringToTypeCache = new Dictionary<string, Type>();
-            _allowedMethodInfos = new Dictionary<MethodInfo, LuauContext>();
+            _memberInfoContextMasks = new Dictionary<MemberInfo, int>();
 
             // Collect all namespaces per assembly:
             _assemblyNamespaces = new Dictionary<Assembly, List<string>>();

--- a/Runtime/Code/Luau/ReflectionList.cs
+++ b/Runtime/Code/Luau/ReflectionList.cs
@@ -77,6 +77,7 @@ namespace Luau {
             [typeof(NetworkTransformUnreliable)] = LuauContextAll,
             [typeof(NetworkIdentity)] = LuauContextAll,
             [typeof(NetworkAnimator)] = LuauContextAll,
+            [typeof(LocalConnectionToClient)] = LuauContextAll,
             [typeof(NetworkConnectionToClient)] = LuauContextAll,
             [typeof(NetworkConnectionToServer)] = LuauContextAll,
             [typeof(NetworkConnection)] = LuauContextAll,

--- a/Runtime/Code/LuauAPI/EmissionModuleAPI.cs
+++ b/Runtime/Code/LuauAPI/EmissionModuleAPI.cs
@@ -1,0 +1,9 @@
+using System;
+using UnityEngine;
+
+[LuauAPI]
+public class EmissionModuleAPI : BaseLuaAPIClass {
+    public override Type GetAPIType() {
+        return typeof(ParticleSystem.EmissionModule);
+    }
+}

--- a/Runtime/Code/LuauAPI/EmissionModuleAPI.cs.meta
+++ b/Runtime/Code/LuauAPI/EmissionModuleAPI.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 49854a68ba3e4e64adb0b707c9d5fe1a
+timeCreated: 1758056356

--- a/Runtime/Code/LuauAPI/ParticleMainModuleAPI.cs
+++ b/Runtime/Code/LuauAPI/ParticleMainModuleAPI.cs
@@ -1,0 +1,9 @@
+using System;
+using UnityEngine;
+
+[LuauAPI]
+public class ParticleMainModuleAPI : BaseLuaAPIClass {
+    public override Type GetAPIType() {
+        return typeof(ParticleSystem.MainModule);
+    }
+}

--- a/Runtime/Code/LuauAPI/ParticleMainModuleAPI.cs.meta
+++ b/Runtime/Code/LuauAPI/ParticleMainModuleAPI.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 020717fbb94b4a5fb9719d1029e6d3fa
+timeCreated: 1758056457

--- a/Runtime/Code/LuauAPI/QualitySettingsAPI.cs
+++ b/Runtime/Code/LuauAPI/QualitySettingsAPI.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
-[LuauAPI(LuauContext.Protected)]
+[LuauAPI(LuauContext.Protected, ContextOverrideList = new []{ "GetQualityLevel", "names" })]
 public class QualitySettingsAPI : BaseLuaAPIClass {
     public override Type GetAPIType() {
         return typeof(QualitySettings);

--- a/Runtime/Code/LuauAPI/VignetteAPI.cs
+++ b/Runtime/Code/LuauAPI/VignetteAPI.cs
@@ -1,0 +1,9 @@
+using System;
+using UnityEngine.Rendering.Universal;
+
+[LuauAPI]
+public class VignetteAPI : BaseLuaAPIClass {
+    public override Type GetAPIType() {
+        return typeof(Vignette);
+    }
+}

--- a/Runtime/Code/LuauAPI/VignetteAPI.cs.meta
+++ b/Runtime/Code/LuauAPI/VignetteAPI.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e98c6a6b55a4047b5a855b6e289788f
+timeCreated: 1758056394

--- a/Runtime/Code/LuauHelper/LuauHelper.cs
+++ b/Runtime/Code/LuauHelper/LuauHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Airship.DevConsole;
 using Luau;
@@ -60,21 +62,37 @@ public class LuauHelper : Singleton<LuauHelper> {
                 var typeAttribute = type.GetCustomAttribute<LuauAPIAttribute>(true);
                 if (typeAttribute == null) continue;
 
-                // Add Luau contextual permissions for the class and methods
-                ReflectionList.AddToReflectionList(type, typeAttribute.AllowedContextsMask);
-                foreach (var methodInfo in type.GetMethods()) {
-                    var methodTypeAttr = methodInfo.GetCustomAttribute<LuauAPIAttribute>();
-                    if (methodTypeAttr == null) {
-                        continue;
-                    }
+                var isLuauAPIClass = type.IsSubclassOf(typeof(BaseLuaAPIClass));
 
-                    ReflectionList.AddToMethodList(methodInfo, methodTypeAttr.AllowedContextsMask);
+                // Add Luau contextual permissions for the class and methods
+                if (!isLuauAPIClass) {
+                    ReflectionList.AddToReflectionList(type, typeAttribute.AllowedContextsMask);
+                    foreach (var memberInfo in type.GetMembers()) {
+                        var methodTypeAttr = memberInfo.GetCustomAttribute<LuauAPIAttribute>();
+                        if (methodTypeAttr == null) {
+                            continue;
+                        }
+                    
+                        ReflectionList.RegisterMemberInfoContextMask(memberInfo,
+                            (int)methodTypeAttr.AllowedContextsMask);
+                    }
                 }
 
-                if (type.IsSubclassOf(typeof(BaseLuaAPIClass))) {
+                if (isLuauAPIClass) {
                     var instance = (BaseLuaAPIClass)Activator.CreateInstance(type);
-                    ReflectionList.AddToReflectionList(instance.GetAPIType(), typeAttribute.AllowedContextsMask);
+                    var apiType = instance.GetAPIType();
+                    ReflectionList.AddToReflectionList(apiType, typeAttribute.AllowedContextsMask);
                     LuauCore.CoreInstance.RegisterBaseAPI(instance);
+
+                    // Override context of individual methods / members
+                    if (typeAttribute.ContextOverrideList != null) {
+                        var overrideNameSet = new HashSet<string>(typeAttribute.ContextOverrideList); 
+                        foreach (var memberInfo in apiType.GetMembers()) {
+                            if (overrideNameSet.Contains(memberInfo.Name)) {
+                                ReflectionList.RegisterMemberInfoContextMask(memberInfo, typeAttribute.ContextOverrideMask);
+                            }
+                        }
+                    }
                 } else {
                     var customApi = new UnityCustomAPI(type);
                     LuauCore.CoreInstance.RegisterBaseAPI(customApi);


### PR DESCRIPTION
- Adds security on property access (before QualitySettings.names was available despite QualitySettingsAPI being marked as protected).
- Adds a way to override member access
`ContextOverrideList = new []{ "GetQualityLevel", "names" }`
By default this will set the context mask for all listed members to ~0 (all access). You can also supply a ContextOverrideMask to LuauAPI if you want to configure the overridden mask.
- Adds support for marking any member with LuauAPI (so you can make properties / fields have custom permission)
- Add overrides for QualitySettingsAPI to access GetQualityLevel & names (we can likely expose more here too, these are just immediately useful for what I'm doing).
- Adds LuauAPIs for ParticleSystem.EmissionModule, ParticleSystem.MainModule, Vignette

Tested client on Airship Player and am able to play BedWars, Minesweeper, Minigolf, Bird TD without any issues related to this.