### PR TITLE
Check for loaded scene before instantiating singleton

### DIFF
--- a/Runtime/Code/Util/Singleton.cs
+++ b/Runtime/Code/Util/Singleton.cs
@@ -30,6 +30,11 @@ public abstract class Singleton<T> : MonoBehaviour where T : MonoBehaviour
 			if (_instance == null) {
 				_instance = (T) FindAnyObjectByType(typeof(T));
 				if (_instance == null) {
+					if (!SceneManager.GetActiveScene().isLoaded) {
+						// Prevent creating singleton when scene is closing
+						return null;
+					}
+					
 					var go = new GameObject();
 					go.name = typeof(T).ToString();
 					


### PR DESCRIPTION
Stopping Unity often results in the following error:
<img width="746" height="136" alt="singleton_err" src="https://github.com/user-attachments/assets/9a8be626-7656-4bae-803f-45ef366005e2" />

> Some objects were not cleaned up when closing the scene. (Did you spawn new GameObjects from OnDestroy?)

Yes, in fact, we did! There are several instances where singletons are accessed from `OnDestroy` methods, [such as this](https://github.com/easy-games/airship/blob/129b9d1f8b7b9cee47e8421f7fecfbb188e0508c/Runtime/Code/Network/Simulation/AirshipOfflineRigidbody.cs#L26).

----------------------

A simple solution to this is to check for the active scene to be loaded before instantiating the GameObject for a new singleton. If the currently-active scene is not loaded, just return `null`. Interestingly, we're already doing null-checking where these singletons are being accessed from `OnDestroy` methods, so this solution seems to work without any extra changes.