### PR TITLE
Track and check plugin init ID to prevent zstd shutdown in different plugin context

### DIFF
--- a/Runtime/Code/Zstd/Zstd.cs
+++ b/Runtime/Code/Zstd/Zstd.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Buffers;
+using UnityEngine;
 using static Code.Zstd.ZstdNative;
 
 namespace Code.Zstd {
@@ -348,9 +349,14 @@ namespace Code.Zstd {
 
 		private bool _disposed;
 		
+#if UNITY_EDITOR
+		private uint _pluginInitId;
+#endif
+		
 		public ZstdContext(ulong scratchBufferSize) {
 #if UNITY_EDITOR
 			ZstdNative.TryInitPlugin();
+			_pluginInitId = ZstdNative.InitId;
 #endif
 			ScratchBuffer = ArrayPool<byte>.Shared.Rent((int)scratchBufferSize);
 			Cctx = ZSTD_createCCtx();
@@ -374,6 +380,12 @@ namespace Code.Zstd {
 				ArrayPool<byte>.Shared.Return(ScratchBuffer);
 			}
 			
+#if UNITY_EDITOR
+			// Prevent calling into the plugin if it is no longer valid (e.g. on editor shutdown):
+			if (_pluginInitId != ZstdNative.InitId) {
+				return;
+			}
+#endif
 			ZSTD_freeCCtx(Cctx);
 			ZSTD_freeDCtx(Dctx);
 		}

--- a/Runtime/Code/Zstd/ZstdNative.cs
+++ b/Runtime/Code/Zstd/ZstdNative.cs
@@ -265,8 +265,15 @@ namespace Code.Zstd {
 		internal delegate ulong ZSTD_DStreamOutSize_Delegate();
 		[NativeDelegate] internal static ZSTD_DStreamOutSize_Delegate ZSTD_DStreamOutSize;
 
+		public static uint InitId {
+			get;
+			private set;
+		}
+
 		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
 		private static void InitPlugin() {
+			InitId++;
+			
 			NativePluginHandles.RegisterPlugin(typeof(ZstdNative));
 
 			Application.quitting -= DeinitPlugin;
@@ -274,6 +281,7 @@ namespace Code.Zstd {
 		}
 
 		private static void DeinitPlugin() {
+			InitId++;
 			_libHandle = IntPtr.Zero;
 		}
 


### PR DESCRIPTION
In the editor, the ZSTD library gets shut down when closing Unity. This seems to happen _before_ C# calls into the plugin to clean up ZSTD resources. This causes a crash.

The fix: Track an "initialization ID" for the plugin & ensure the ID at construction matches the ID at destruction.

There is probably more work to be done here to make this better, but gotta just patch the crash issue for now.