### PR TITLE
BinaryBlob decode bounds checking

### DIFF
--- a/Runtime/Code/AirshipConst.cs
+++ b/Runtime/Code/AirshipConst.cs
@@ -2,11 +2,11 @@
 
 namespace Code {
     public static class AirshipConst {
-        public const int playerVersion = 16;
+        public const int playerVersion = 17;
 
         /// <summary>
         /// The server will kick clients that have a playerVersion lower than this value.
         /// </summary>
-        public const int minAcceptedPlayerVersionOnServer = 15;
+        public const int minAcceptedPlayerVersionOnServer = 17;
     }
 }


### PR DESCRIPTION
This PR commits a Luau plugin change that ensures that BinaryBlob's Decode method does proper bounds checking, ensuring there is no attempt to read data past the actual length of the data provided.