### PR TITLE
Only assign GoogleSignIn config if it is null

### DIFF
--- a/Runtime/Code/Auth/AuthManager.cs
+++ b/Runtime/Code/Auth/AuthManager.cs
@@ -136,7 +136,7 @@ public class AuthManager {
         });
 
 #if UNITY_ANDROID
-        GoogleSignIn.Configuration = new GoogleSignInConfiguration() {
+		GoogleSignIn.Configuration ??= new GoogleSignInConfiguration() {
 			RequestEmail = true,
 			RequestProfile = true,
 			RequestAuthCode = true,
@@ -144,7 +144,7 @@ public class AuthManager {
 #if UNITY_EDITOR || UNITY_STANDALONE
 			ClientSecret = clientSecret,
 #endif
-        };
+		};
 #endif
         
 #if AIRSHIP_ANDROID_DEBUG


### PR DESCRIPTION
Fixes exceptions being thrown: `DefaultInstance already created. Cannot change configuration after creation.` The configuration can only be assigned once. So if an Android user tries to sign in again (e.g. after a logout), the exception would be thrown.

This PR just ensures that the configuration is only set if it's null.