### PR TITLE
Ability to access all voxels in a voxel world

### DIFF
--- a/Runtime/Code/VoxelWorld/VoxelWorld.cs
+++ b/Runtime/Code/VoxelWorld/VoxelWorld.cs
@@ -693,6 +693,29 @@ public partial class VoxelWorld : MonoBehaviour {
         return WorldPosToChunkKey(globalCoordinate);
     }
 
+    public Chunk[] GetChunks() {
+        return chunks.Values.ToArray();
+    }
+
+    public static Vector3 GetChunkKey(Chunk chunk) {
+        return chunk.GetKey();
+    }
+
+    public static int[] GetVoxelKeysInChunk(Chunk chunk) {
+        return chunk.GetKeysWithVoxels().ToArray();
+    }
+
+    public static ushort GetVoxelDataFromKey(Chunk chunk, int key) {
+        return chunk.readWriteVoxel[key];
+    }
+
+    public static BinaryBlob GetVoxelCustomDataFromKey(Chunk chunk, ushort key) {
+        if (chunk.customDataMap.TryGetValue(key, out BinaryBlob value)) {
+            return value;
+        }
+        return null;
+    }
+
     [HideFromTS]
     public Chunk GetChunkByVoxel(Vector3Int pos) {
         var chunkKey = WorldPosToChunkKey(pos);
@@ -761,7 +784,17 @@ public partial class VoxelWorld : MonoBehaviour {
 
         return value.GetCustomDataAt(posi);
     }
-    
+
+    public void RemoveVoxelCustomDataAt(Vector3 pos) {
+        var posi = FloorInt(pos);
+        var chunkKey = WorldPosToChunkKey(posi);
+        if (!chunks.TryGetValue(chunkKey, out var value)) {
+            return;
+        }
+
+        value.RemoveCustomDataAt(posi);
+    }
+
     public Color32 GetVoxelColorAt(Vector3 pos) {
         var posi = FloorInt(pos);
         var chunkKey = WorldPosToChunkKey(posi);

--- a/Runtime/Code/VoxelWorld/VoxelWorldChunk.cs
+++ b/Runtime/Code/VoxelWorld/VoxelWorldChunk.cs
@@ -492,14 +492,27 @@ namespace VoxelWorldStuff {
             customDataMap[(ushort)key] = data;
         }
 
-        public BinaryBlob GetCustomDataAt(Vector3Int worldPos) {
+        /// <summary>
+        /// Remove custom data from a voxel id
+        /// </summary>
+        public void RemoveCustomDataAt(Vector3Int worldPos) {
             var key = WorldPosToVoxelIndex(worldPos);
 
             if (key < 0 || key >= chunkSize * chunkSize * chunkSize) {
-                return null;
+                return;
             }
 
-            return customDataMap[(ushort)key];
+            customDataMap.Remove((ushort)key);
+        }
+
+        public BinaryBlob GetCustomDataAt(Vector3Int worldPos) {
+            var key = WorldPosToVoxelIndex(worldPos);
+
+            if (customDataMap.TryGetValue((ushort)key, out BinaryBlob value)) {
+                return value;
+            }
+
+            return null;
         }
 
 
@@ -524,7 +537,7 @@ namespace VoxelWorldStuff {
         /// This may require looping over all positions in chunk if it is being run
         /// for the first time.
         /// </summary>
-        private HashSet<int> GetKeysWithVoxels() {
+        public HashSet<int> GetKeysWithVoxels() {
             if (keysWithVoxelsDirty) {
                 keysWithVoxels.Clear();
                 for (var x = 0; x < chunkSize; x++) {


### PR DESCRIPTION
## Summary
- Added functions to access voxel data from a chunk from typescript

## Problem
- A lot of the VoxelWorld and Chunk methods exposed in typescript have invalid CS types that cannot be accessed and throws an error
- There was no clear way to get all chunks/voxels in a current world from typescript limiting developers ability to loop though blocks on load

## Changes
- `VoxelWorld.cs`
    - Added function to get all chunks within a VoxelWorld in typescript
    - Added function to remove custom data from a voxel which was previously not possible via typescript
    - Added a group of functions for indexing voxels and getting data straight from a chunk which can help performance when looping though all voxels as you don't need to check for a chunk, calculate the key from position then see if it exists and then do that for the block id, rotation, and custom data one by one
- `VoxelWorldChunk.cs`
    - Added RemoveCustomDataAt for reasons listed previously
    - Changed GetKeysWithVoxels access to public so it can be accessed in VoxelWorld

## Behavior After
- Developers can now access all voxels in a 

## Testing
All functionality of the changes have been tested in my project Industrio to solve a problem that motivated me to make these changes.
Below is the function used in Industrio to loop tough all active voxels in a world:
```ts
export function ExecuteAllVoxels(voxelWorld: VoxelWorld, func: (position: Vector3, voxelData: number, customData: BinaryBlob | undefined) => void, execPerFrame: number = 100): void {
    let execCount = 0;
    const chunks = voxelWorld.GetChunks();
    for (let chunkIndex = 0; chunkIndex < chunks.size(); chunkIndex++) {
        const chunk = chunks[chunkIndex];
        const chunkPos = VoxelWorld.GetChunkKey(chunk);
        const voxelKeys = VoxelWorld.GetVoxelKeysInChunk(chunk);
        for (let keyIndex = 0; keyIndex < voxelKeys.size(); keyIndex++) {
            const voxelKey = voxelKeys[keyIndex];
            const voxelData = VoxelWorld.GetVoxelDataFromKey(chunk, voxelKey);
            const position = VoxelChunkIndexToLocalPos(voxelKey).add(chunkPos.mul(ChunkSize));
            func(position, voxelData, VoxelWorld.GetVoxelCustomDataFromKey(chunk, voxelKey));
            execCount++;
            if (execCount % execPerFrame) WaitFrame();
        }
    }
}
```